### PR TITLE
Add the input to the optimal process as an output of the OptimizationWorkChain

### DIFF
--- a/aiida_optimize/_optimization_workchain.py
+++ b/aiida_optimize/_optimization_workchain.py
@@ -12,7 +12,6 @@ from aiida import orm
 from aiida.engine import WorkChain, while_
 from aiida.engine.launch import run_get_node
 from aiida.engine.utils import is_process_function
-
 from aiida_tools import check_workchain_step
 from aiida_tools.process_inputs import PROCESS_INPUT_KWARGS, load_object
 
@@ -65,7 +64,11 @@ class OptimizationWorkChain(WorkChain):
             cls.create_optimizer,
             while_(cls.not_finished)(cls.launch_evaluations, cls.get_results), cls.finalize
         )
-        spec.output('optimal_process_input', help='Input value of the optimal evaluation process.')
+        spec.output(
+            'optimal_process_input',
+            help='Input value of the optimal evaluation process.',
+            required=False
+        )
         spec.output(
             'optimal_process_output', help='Output value of the optimal evaluation process.'
         )
@@ -153,7 +156,7 @@ class OptimizationWorkChain(WorkChain):
             if not opt.is_finished_ok:
                 return self.exit_codes.ERROR_ENGINE_FAILED
             optimal_process_input = opt.result_input_value
-            optimal_process_input.store()
+            assert optimal_process_input.is_stored
             self.out('optimal_process_input', optimal_process_input)
             optimal_process_output = opt.result_output_value
             optimal_process_output.store()

--- a/aiida_optimize/_optimization_workchain.py
+++ b/aiida_optimize/_optimization_workchain.py
@@ -65,6 +65,7 @@ class OptimizationWorkChain(WorkChain):
             cls.create_optimizer,
             while_(cls.not_finished)(cls.launch_evaluations, cls.get_results), cls.finalize
         )
+        spec.output('optimal_process_input', help='Input value of the optimal evaluation process.')
         spec.output(
             'optimal_process_output', help='Output value of the optimal evaluation process.'
         )
@@ -151,7 +152,10 @@ class OptimizationWorkChain(WorkChain):
         with self.optimizer() as opt:
             if not opt.is_finished_ok:
                 return self.exit_codes.ERROR_ENGINE_FAILED
-            optimal_process_output = opt.result_value
+            optimal_process_input = opt.result_input_value
+            optimal_process_input.store()
+            self.out('optimal_process_input', optimal_process_input)
+            optimal_process_output = opt.result_output_value
             optimal_process_output.store()
             self.out('optimal_process_output', optimal_process_output)
             result_index = opt.result_index

--- a/aiida_optimize/_optimization_workchain.py
+++ b/aiida_optimize/_optimization_workchain.py
@@ -156,8 +156,9 @@ class OptimizationWorkChain(WorkChain):
             if not opt.is_finished_ok:
                 return self.exit_codes.ERROR_ENGINE_FAILED
             optimal_process_input = opt.result_input_value
-            assert optimal_process_input.is_stored
-            self.out('optimal_process_input', optimal_process_input)
+            if optimal_process_input is not None:
+                assert optimal_process_input.is_stored
+                self.out('optimal_process_input', optimal_process_input)
             optimal_process_output = opt.result_output_value
             optimal_process_output.store()
             self.out('optimal_process_output', optimal_process_output)

--- a/aiida_optimize/engines/_bisection.py
+++ b/aiida_optimize/engines/_bisection.py
@@ -9,7 +9,6 @@ Defines a 1D bisection optimization engine.
 import typing as ty
 
 from aiida import orm
-# from aiida.orm.nodes.data.base import to_aiida_type
 
 from ..helpers import get_nested_result
 from ._result_mapping import Result

--- a/aiida_optimize/engines/_bisection.py
+++ b/aiida_optimize/engines/_bisection.py
@@ -9,6 +9,7 @@ Defines a 1D bisection optimization engine.
 import typing as ty
 
 from aiida import orm
+# from aiida.orm.nodes.data.base import to_aiida_type
 
 from ..helpers import get_nested_result
 from ._result_mapping import Result
@@ -93,7 +94,7 @@ class _BisectionImpl(OptimizationEngineImpl):
             else:
                 self.lower = self.average
 
-    def _get_optimal_result(self) -> ty.Tuple[int, Result]:
+    def _get_optimal_result(self) -> ty.Tuple[int, ty.Any, Result]:
         """
         Return the index and optimization value of the best evaluation workflow.
         """
@@ -101,11 +102,15 @@ class _BisectionImpl(OptimizationEngineImpl):
             key: get_nested_result(value.output, self.result_key)
             for key, value in self._result_mapping.items()
         }
-        return min(output_values.items(), key=lambda item: abs(item[1].value - self.target_value))
+        opt_index, opt_output = min(
+            output_values.items(), key=lambda item: abs(item[1].value - self.target_value)
+        )
+        opt_input = self._result_mapping[opt_index].input[self.input_key]
+        return (opt_index, opt_input, opt_output)
 
     @property
     def result_value(self) -> Result:
-        return self._get_optimal_result()[1]
+        return self._get_optimal_result()[2]
 
     @property
     def result_index(self) -> int:

--- a/aiida_optimize/engines/_bisection.py
+++ b/aiida_optimize/engines/_bisection.py
@@ -107,14 +107,6 @@ class _BisectionImpl(OptimizationEngineImpl):
         opt_input = self._result_mapping[opt_index].input[self.input_key]
         return (opt_index, opt_input, opt_output)
 
-    @property
-    def result_value(self) -> Result:
-        return self._get_optimal_result()[2]
-
-    @property
-    def result_index(self) -> int:
-        return self._get_optimal_result()[0]
-
 
 class Bisection(OptimizationEngineWrapper):
     """

--- a/aiida_optimize/engines/_convergence.py
+++ b/aiida_optimize/engines/_convergence.py
@@ -193,10 +193,6 @@ class _ConvergenceImpl(OptimizationEngineImpl):
         distance within convergence window)
         """
         opt_index = len(self.result_values) - self.convergence_window
-
-        import pdb
-        pdb.set_trace()
-
         opt_input = self._result_mapping[opt_index].input[self.input_key]
         opt_output = get_nested_result(self._result_mapping[opt_index].output, self.result_key)
 

--- a/aiida_optimize/engines/_convergence.py
+++ b/aiida_optimize/engines/_convergence.py
@@ -182,12 +182,10 @@ class _ConvergenceImpl(OptimizationEngineImpl):
         output_keys = sorted(outputs.keys())  # Sort keys to preserve evaluation order
         output_values = [outputs[key] for key in output_keys]
         self.result_values += [
-            get_nested_result(val, self.result_key)
-            # val[self.result_key]
-            for val in output_values
+            get_nested_result(val, self.result_key) for val in output_values
         ]  # Values are AiiDA types
 
-    def _get_optimal_result(self) -> ty.Tuple[int, ty.Any, Result]:
+    def _get_optimal_result(self) -> ty.Tuple[int, orm.Node, orm.Node]:
         """
         Retrieve the converged index and result value (output value, _not_ max
         distance within convergence window)

--- a/aiida_optimize/engines/_convergence.py
+++ b/aiida_optimize/engines/_convergence.py
@@ -187,15 +187,20 @@ class _ConvergenceImpl(OptimizationEngineImpl):
             for val in output_values
         ]  # Values are AiiDA types
 
-    def _get_optimal_result(self) -> ty.Tuple[int, Result]:
+    def _get_optimal_result(self) -> ty.Tuple[int, ty.Any, Result]:
         """
         Retrieve the converged index and result value (output value, _not_ max
         distance within convergence window)
         """
-        return (
-            len(self.result_values) - self.convergence_window,
-            self.result_values[-self.convergence_window]
-        )
+        opt_index = len(self.result_values) - self.convergence_window
+
+        import pdb
+        pdb.set_trace()
+
+        opt_input = self._result_mapping[opt_index].input[self.input_key]
+        opt_output = get_nested_result(self._result_mapping[opt_index].output, self.result_key)
+
+        return (opt_index, opt_input, opt_output)
 
 
 class Convergence(OptimizationEngineWrapper):

--- a/aiida_optimize/engines/_nelder_mead.py
+++ b/aiida_optimize/engines/_nelder_mead.py
@@ -24,6 +24,7 @@ import scipy.linalg as la
 from decorator import decorator
 
 from aiida import orm
+# from aiida.orm.nodes.data.base import to_aiida_type
 
 from ..helpers import get_nested_result
 from .base import OptimizationEngineImpl, OptimizationEngineWrapper
@@ -284,7 +285,7 @@ class _NelderMeadImpl(OptimizationEngineImpl):
 
     @property
     def result_value(self):
-        value = super().result_value
+        value = super().result_value  # pylint: disable=no-member
         assert value.value == self.fun_simplex[0]
         return value
 
@@ -296,7 +297,13 @@ class _NelderMeadImpl(OptimizationEngineImpl):
             k: get_nested_result(v.output, self.result_key)
             for k, v in self._result_mapping.items()
         }
-        return min(cost_values.items(), key=lambda item: item[1].value)
+        opt_index, opt_output = min(cost_values.items(), key=lambda item: item[1].value)
+        opt_input = self._result_mapping[opt_index].input[self.input_key]
+
+        import pdb
+        pdb.set_trace()
+
+        return (opt_index, opt_input, opt_output)
 
 
 class NelderMead(OptimizationEngineWrapper):

--- a/aiida_optimize/engines/_nelder_mead.py
+++ b/aiida_optimize/engines/_nelder_mead.py
@@ -24,7 +24,6 @@ import scipy.linalg as la
 from decorator import decorator
 
 from aiida import orm
-# from aiida.orm.nodes.data.base import to_aiida_type
 
 from ..helpers import get_nested_result
 from .base import OptimizationEngineImpl, OptimizationEngineWrapper
@@ -299,9 +298,6 @@ class _NelderMeadImpl(OptimizationEngineImpl):
         }
         opt_index, opt_output = min(cost_values.items(), key=lambda item: item[1].value)
         opt_input = self._result_mapping[opt_index].input[self.input_key]
-
-        import pdb
-        pdb.set_trace()
 
         return (opt_index, opt_input, opt_output)
 

--- a/aiida_optimize/engines/_parameter_sweep.py
+++ b/aiida_optimize/engines/_parameter_sweep.py
@@ -48,7 +48,10 @@ class _ParameterSweepImpl(OptimizationEngineImpl):
             k: get_nested_result(v.output, self._result_key)
             for k, v in self._result_mapping.items()
         }
-        return min(cost_values.items(), key=lambda item: item[1].value)
+        opt_index, opt_output = min(cost_values.items(), key=lambda item: item[1].value)
+        input_keys = list(self._parameters[opt_index].keys())
+        opt_input = self._result_mapping[opt_index].input[input_keys[0]]
+        return (opt_index, opt_input, opt_output)
 
 
 class ParameterSweep(OptimizationEngineWrapper):

--- a/aiida_optimize/engines/base.py
+++ b/aiida_optimize/engines/base.py
@@ -91,25 +91,33 @@ class OptimizationEngineImpl:
         """
 
     @property
-    def result_value(self) -> ty.Any:
-        """
-        Return the output value of the optimal evaluation.
-        """
-        _, value = self._get_optimal_result()
-        return value
-
-    @property
     def result_index(self) -> int:
         """
         Returns the index (in the result mapping) of the optimal evaluation.
         """
-        index, _ = self._get_optimal_result()
+        index, _, _ = self._get_optimal_result()
         return index
 
-    @abstractmethod
-    def _get_optimal_result(self) -> ty.Tuple[int, ty.Any]:
+    @property
+    def result_input_value(self) -> ty.Any:
         """
-        Return the index and optimization value of the best evaluation process.
+        Return the input value of the optimal evaluation.
+        """
+        _, value, _ = self._get_optimal_result()
+        return value
+
+    @property
+    def result_output_value(self) -> ty.Any:
+        """
+        Return the output value of the optimal evaluation.
+        """
+        _, _, value = self._get_optimal_result()
+        return value
+
+    @abstractmethod
+    def _get_optimal_result(self) -> ty.Tuple[int, ty.Any, ty.Any]:
+        """
+        Return the index, input value, and output value of the best evaluation process.
         """
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,16 +6,15 @@
 Configuration file for pytest tests of aiida-optimize.
 """
 
-import os
 import operator
+import os
 from collections import ChainMap
 
 import numpy as np
 import pytest
-
 from aiida import orm
+from aiida.common import exceptions
 from aiida.engine.launch import run_get_node, submit
-
 from aiida_optimize import OptimizationWorkChain
 
 # This is needed so that the daemon can also load the local modules.
@@ -82,25 +81,31 @@ def check_optimization(
             evaluate=evaluate
         )
 
-        if isinstance(result_node.outputs.optimal_process_input, orm.BaseType):
-            optimal_process_input = result_node.outputs.optimal_process_input.value
-        elif isinstance(result_node.outputs.optimal_process_input, orm.List):
-            optimal_process_input = result_node.outputs.optimal_process_input.get_list()
-        else:
-            raise ValueError(
-                f'`optimal_process_input` {result_node.outputs.optimal_process_input} is not of a supported AiiDA type for testing'
-            )
-
         assert 'optimal_process_uuid' in result_node.outputs
         assert np.isclose(result_node.outputs.optimal_process_output.value, f_exact, atol=ftol)
-        assert np.allclose(type(x_exact)(optimal_process_input), x_exact, atol=xtol)
 
         calc = orm.load_node(result_node.outputs.optimal_process_uuid.value)
         assert np.allclose(type(x_exact)(input_getter(calc.inputs)), x_exact, atol=xtol)
+
+        try:
+            optimal_process_input_node = result_node.outputs.optimal_process_input
+        except exceptions.NotExistentAttributeError:
+            return
+
+        if isinstance(optimal_process_input_node, orm.BaseType):
+            optimal_process_input = optimal_process_input_node.value
+        elif isinstance(optimal_process_input_node, orm.List):
+            optimal_process_input = optimal_process_input_node.get_list()
+        else:
+            optimal_process_input = optimal_process_input_node
+
+        getter_input = input_getter(calc.inputs)
+        if isinstance(getter_input, orm.Node):
+            assert getter_input.uuid == optimal_process_input_node.uuid
+
+        assert np.allclose(type(x_exact)(optimal_process_input), x_exact, atol=xtol)
         assert np.allclose(
-            type(x_exact)(input_getter(calc.inputs)),
-            type(x_exact)(optimal_process_input),
-            atol=xtol
+            type(x_exact)(getter_input), type(x_exact)(optimal_process_input), atol=xtol
         )
 
     return inner


### PR DESCRIPTION
Often, the input value is just as, or more, important than the output value of a function when optimizing. So, to make access to the input of the optimal process, we add the `optimal_process_input` as an output of the `OptimizationWorkChain` and update all of the currently implemented optimization engines to support the new output.