### PR TITLE
Add `get_engine_outputs` to `EngineImpl` base class.

### DIFF
--- a/aiida_optimize/_optimization_workchain.py
+++ b/aiida_optimize/_optimization_workchain.py
@@ -73,6 +73,7 @@ class OptimizationWorkChain(WorkChain):
             'optimal_process_output', help='Output value of the optimal evaluation process.'
         )
         spec.output('optimal_process_uuid', help='UUID of the optimal evaluation process.')
+        spec.output_namespace('engine_outputs', required=False, dynamic=True)
 
     @contextmanager
     def optimizer(self):
@@ -165,6 +166,9 @@ class OptimizationWorkChain(WorkChain):
             result_index = opt.result_index
             optimal_process = self.ctx[self.eval_key(result_index)]
             self.out('optimal_process_uuid', orm.Str(optimal_process.uuid).store())
+
+            if hasattr(opt, 'get_engine_outputs'):
+                self.out('engine_outputs', opt.get_engine_outputs())
 
     def eval_key(self, index):
         """

--- a/aiida_optimize/engines/base.py
+++ b/aiida_optimize/engines/base.py
@@ -17,7 +17,11 @@ from ._result_mapping import ResultMapping, Result
 
 yaml.representer.Representer.add_representer(ABCMeta, yaml.representer.Representer.represent_name)
 
-__all__ = ['OptimizationEngineImpl', 'OptimizationEngineWrapper']
+__all__ = (
+    'OptimizationEngineImpl',
+    'OptimizationEngineImplWithOutputs',
+    'OptimizationEngineWrapper',
+)
 
 
 class OptimizationEngineImpl:
@@ -118,6 +122,24 @@ class OptimizationEngineImpl:
     def _get_optimal_result(self) -> ty.Tuple[int, ty.Any, ty.Any]:
         """
         Return the index, input value, and output value of the best evaluation process.
+        """
+
+
+class OptimizationEngineImplWithOutputs:
+    """
+    Base class for the optimization engine implementation emitting custom outputs.
+    """
+    @abstractmethod
+    def get_engine_outputs(self) -> ty.Dict[str, ty.Any]:
+        """
+        Return the custom outputs created by the engine, at the end of
+        the run.
+
+        The result must be compatible with `WorkChain.out`, i.e. its
+        keys are labels, and the values are either AiiDA nodes, or
+        nested dictionaries.
+
+        All AiiDA nodes returned *must* already be stored.
         """
 
 

--- a/tests/test_engine_outputs.py
+++ b/tests/test_engine_outputs.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+
+# © 2017-2019, ETH Zurich, Institut für Theoretische Physik
+# Author: Dominik Gresch <greschd@gmx.ch>
+"""
+Tests for the OptimizationWorkChain.
+"""
+
+from aiida import orm
+
+from aiida_optimize.engines.base import OptimizationEngineImplWithOutputs
+from aiida_optimize.engines._bisection import Bisection, _BisectionImpl
+
+from sample_processes import Echo
+
+
+class BisectionWithCustomOutputImpl(_BisectionImpl, OptimizationEngineImplWithOutputs):
+    def get_engine_outputs(self):
+        return {'a': orm.Int(3).store(), 'b': orm.Float(2.3).store()}
+
+
+class BisectionWithCustomOutput(Bisection):
+    _IMPL_CLASS = BisectionWithCustomOutputImpl
+
+
+def test_custom_output(run_optimization):
+    """
+    Simple test of the OptimizationWorkChain, with the Bisection engine.
+    """
+
+    tol = 1e-1
+    node = run_optimization(
+        engine=BisectionWithCustomOutput,
+        engine_kwargs=dict(
+            lower=-1.1,
+            upper=1.,
+            tol=tol,
+        ),
+        func_workchain=Echo,
+    )
+    assert 'engine_outputs__a' in node.outputs
+    assert 'engine_outputs__b' in node.outputs
+    assert node.outputs.engine_outputs__a.value == 3
+    assert node.outputs.engine_outputs__b.value == 2.3


### PR DESCRIPTION
Allow optimization engines to emit custom outputs at the end of the optimization run, through a `get_engine_outputs` method. If the engine has such a method, the `OptimizationWorkChain` will emit the outputs in the `engine_outputs` namespace.

Partially adresses #35, tagging @unkcpz for comment.