### PR TITLE
Feature/nelder mead outputs

### DIFF
--- a/aiida_optimize/_optimization_workchain.py
+++ b/aiida_optimize/_optimization_workchain.py
@@ -154,6 +154,8 @@ class OptimizationWorkChain(WorkChain):
         """
         self.report('Finalizing optimization procedure.')
         with self.optimizer() as opt:
+            if hasattr(opt, 'get_engine_outputs'):
+                self.out('engine_outputs', opt.get_engine_outputs())
             if not opt.is_finished_ok:
                 return self.exit_codes.ERROR_ENGINE_FAILED
             optimal_process_input = opt.result_input_value
@@ -166,9 +168,6 @@ class OptimizationWorkChain(WorkChain):
             result_index = opt.result_index
             optimal_process = self.ctx[self.eval_key(result_index)]
             self.out('optimal_process_uuid', orm.Str(optimal_process.uuid).store())
-
-            if hasattr(opt, 'get_engine_outputs'):
-                self.out('engine_outputs', opt.get_engine_outputs())
 
     def eval_key(self, index):
         """

--- a/aiida_optimize/engines/_nelder_mead.py
+++ b/aiida_optimize/engines/_nelder_mead.py
@@ -318,6 +318,9 @@ class _NelderMeadImpl(OptimizationEngineImpl):
 
         return (opt_index, opt_input, opt_output)
 
+    def get_engine_outputs(self):
+        return {'last_simplex': orm.List(list=self.simplex.tolist()).store()}
+
 
 class NelderMead(OptimizationEngineWrapper):
     """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -70,6 +70,7 @@ def check_optimization(
         f_exact,
         evaluate=None,
         input_getter=operator.attrgetter('x'),
+        output_port_names=None
     ):
 
         func_workchain = getattr(sample_processes, func_workchain_name)
@@ -108,6 +109,10 @@ def check_optimization(
             type(x_exact)(getter_input), type(x_exact)(optimal_process_input), atol=xtol
         )
 
+        if output_port_names is not None:
+            for name in output_port_names:
+                assert name in result_node.outputs
+
     return inner
 
 
@@ -139,6 +144,7 @@ def check_error(
         )
 
         assert result_node.exit_status == exit_status
+
         if output_port_names is not None:
             for name in output_port_names:
                 assert name in result_node.outputs

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -126,6 +126,7 @@ def check_error(
         engine_kwargs,
         exit_status,
         evaluate=None,
+        output_port_names=None
     ):
 
         func_workchain = getattr(sample_processes, func_workchain_name)
@@ -138,5 +139,8 @@ def check_error(
         )
 
         assert result_node.exit_status == exit_status
+        if output_port_names is not None:
+            for name in output_port_names:
+                assert name in result_node.outputs
 
     return inner

--- a/tests/test_nelder_mead.py
+++ b/tests/test_nelder_mead.py
@@ -72,5 +72,8 @@ def test_nelder_mead_max_iter(check_error):
             max_iter=10,
         ),
         func_workchain_name='rosenbrock',
-        exit_status=202
+        exit_status=202,
+        output_port_names=[
+            'engine_outputs__last_simplex',
+        ]
     )

--- a/tests/test_nelder_mead.py
+++ b/tests/test_nelder_mead.py
@@ -54,6 +54,9 @@ def test_nelder_mead(
         ftol=ftol,
         x_exact=x_exact,
         f_exact=f_exact,
+        output_port_names=[
+            'engine_outputs__last_simplex',
+        ]
     )
 
 


### PR DESCRIPTION
Added the output `last_simplex` to the `optimization_workchain` outputs
when the `nelder_mead` engine is used.
Also moved the call that returns the engine-dependent outputs
in the optimization_workchain before the checks on the correct
end of the calculation.
Some outputs are needed also for calculations when the
optimization is not reached.