### PR TITLE
Fix readthedocs build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,6 +5,12 @@
 # Required
 version: 2
 
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.9"
+
 # Build documentation in the doc/ directory with Sphinx
 sphinx:
   configuration: doc/source/conf.py
@@ -14,7 +20,6 @@ formats: []
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.9
   install:
     - method: pip
       path: .


### PR DESCRIPTION
The `python.version` option for '' in the `.readthedocs.yml` was deprecated in 
favor of `build.tools.python`. This showed in the switch from 3.8 to 3.9, which 
only supports the new config.